### PR TITLE
Don't remove pg_comparator script in clean target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ name		= pg_comparator
 EXTENSION	= pgcmp
 SCRIPTS		= $(name)
 MODULES		= $(EXTENSION)
-DATA_built	= $(name)
 DATA		= pgcmp--3.0.sql
 DOCS		= README.$(name)
 


### PR DESCRIPTION
The Debian package fails to build the 2.3.0 release because the `pg_compatator` script is removed in the `clean` target (because it's in `DATA_built`).

There are no rules in the `Makefile` to build the script, and it is already included in `SCRIPTS`, so it looks like the `pg_compatator` script should simply not be in `DATA_built` as well.

The Debian package build process consists of the following steps:

 * `make clean`
 * `./configure` (not applicable to pg_comparator)
 * `make`
 * `make install`

This causes the script to be removed before it is required by `make` & `make install`.