### PR TITLE
Add extension control file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,16 @@
 
 name		= pg_comparator
 
+EXTVERSION	= 3.0
+
 EXTENSION	= pgcmp
 SCRIPTS		= $(name)
 MODULES		= $(EXTENSION)
 DATA_built	= $(name)
-DATA		= pgcmp--3.0.sql
+DATA		= $(EXTENSION)--$(EXTVERSION).sql
 DOCS		= README.$(name)
 
-EXTRA_CLEAN	= $(name).1 $(name).html pod2htm?.tmp
+EXTRA_CLEAN	= $(name).1 $(name).html pod2htm?.tmp $(EXTENSION).control
 
 # get postgresql extension infrastructure
 PG_CONFIG	= pg_config
@@ -35,6 +37,9 @@ pgcmp.o: jenkins.c fnv.c
 
 pgsql_install: install
 pgsql_uninstall: uninstall
+
+$(EXTENSION).control: $(EXTENSION).control.in
+	sed -e 's/@EXTVERSION@/$(EXTVERSION)/g' $< > $@
 
 #
 # MySQL stuff

--- a/pgcmp.control.in
+++ b/pgcmp.control.in
@@ -1,0 +1,3 @@
+# pg_comparator extension
+comment = 'pg_comparator extension'
+default_version = @EXTVERSION@


### PR DESCRIPTION
Fixes build failure:
```
make[1]: *** No rule to make target 'pgcmp.control', needed by 'all'.  Stop.
```

#2 should be applied first

For the related documentation, see: https://www.postgresql.org/docs/9.6/static/extend-extensions.html